### PR TITLE
Adds a const fn `from_static` which allows instantiating a `Symbol` in static contexts like a const

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,16 +10,16 @@ repository = "https://github.com/remexre/symbol-rs"
 version = "0.1.9"
 
 [dependencies]
-lazy_static = "1.0.0"
+lazy_static = "1"
 spin = { version = "0.4.6", default-features = false }
 
 # Requires the std feature.
 gc = { optional = true, version = "0.3.2" }
 
 # Requires the std feature.
-radix_trie = { optional = true, version = "0.2.0" }
+radix_trie = { optional = true, version = "0.2" }
 
-serde = { features = ["derive"], optional = true, version = "1.0.0" }
+serde = { features = ["derive"], optional = true, version = "1" }
 
 [features]
 default = ["std"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,6 @@ documentation = "https://docs.rs/symbol"
 homepage = "https://github.com/remexre/symbol-rs"
 license = "Apache-2.0/MIT"
 name = "symbol"
-readme = "README.md"
 repository = "https://github.com/remexre/symbol-rs"
 version = "0.1.9"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -113,6 +113,10 @@ impl Symbol {
 
         Symbol::from(n)
     }
+
+    pub const fn from_static(lit: &'static str) -> Symbol {
+        Symbol { s: lit }
+    }
 }
 
 impl Debug for Symbol {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -114,6 +114,14 @@ impl Symbol {
         Symbol::from(n)
     }
 
+    /// A const fn that allows creating a [`Symbol`] from a `&'static str`
+    ///
+    /// ### Example:
+    /// ```
+    /// use symbol::Symbol;
+    ///
+    /// const MY_SYMBOL: Symbol = Symbol::from_static("this is a symbol");
+    /// ```
     pub const fn from_static(lit: &'static str) -> Symbol {
         Symbol { s: lit }
     }


### PR DESCRIPTION
e.g.:

```rust
const MY_SYMBOL: Symbol = Symbol::from_static("this is a symbol");
```

fixes #3 